### PR TITLE
feat: add support for quest helper highlight

### DIFF
--- a/src/main/java/com/osrstranslate/OsrsTranslatePlugin.java
+++ b/src/main/java/com/osrstranslate/OsrsTranslatePlugin.java
@@ -149,7 +149,7 @@ public class OsrsTranslatePlugin extends Plugin
             if (event.getGroupId() == interfaceId)
             {
                 final int id = interfaceId;
-                clientThread.invokeLater(() -> translateInterface(id));
+                QuestHelperCompat.scheduleDialogTranslation(clientThread, id, () -> translateInterface(id));
                 return;
             }
         }
@@ -183,24 +183,27 @@ public class OsrsTranslatePlugin extends Plugin
                 .replaceAll("\\s+", " ")
                 .trim();
 
-            if (clean.startsWith("You've spent")
-                && clean.contains("in the world since you arrived")
-                && clean.endsWith("ago."))
+            String qhPrefix = QuestHelperCompat.extractNumberingPrefix(clean);
+            String lookup = qhPrefix.isEmpty() ? clean : QuestHelperCompat.stripNumberingPrefix(clean);
+
+            if (lookup.startsWith("You've spent")
+                && lookup.contains("in the world since you arrived")
+                && lookup.endsWith("ago."))
             {
-                String ptHans = translateHans(clean);
+                String ptHans = translateHans(lookup);
                 if (ptHans != null)
                 {
-                    widget.setText(ptHans);
+                    widget.setText(qhPrefix + ptHans);
                     return;
                 }
             }
 
-            String pt = translations.get(clean);
+            String pt = translations.get(lookup);
             if (pt == null)
             {
                 for (PatternEntry entry : regexTranslations)
                 {
-                    Matcher matcher = entry.pattern.matcher(clean);
+                    Matcher matcher = entry.pattern.matcher(lookup);
                     if (matcher.matches())
                     {
                         String result = entry.translation;
@@ -216,7 +219,7 @@ public class OsrsTranslatePlugin extends Plugin
 
             if (pt != null)
             {
-                widget.setText(pt);
+                widget.setText(qhPrefix + pt);
                 return;
             }
         }

--- a/src/main/java/com/osrstranslate/QuestHelperCompat.java
+++ b/src/main/java/com/osrstranslate/QuestHelperCompat.java
@@ -1,0 +1,50 @@
+package com.osrstranslate;
+
+import net.runelite.api.widgets.InterfaceID;
+import net.runelite.client.callback.ClientThread;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+final class QuestHelperCompat
+{
+    private static final Pattern NUMBERING_PREFIX = Pattern.compile("^\\[\\d+\\]\\s+");
+
+    private QuestHelperCompat()
+    {
+    }
+
+    // Agenda a traducao para rodar depois do destaque do Quest Helper.
+    //
+    // Para DIALOG_OPTION (grupo 219, a unica interface destacada pelo QH) encadeamos
+    // invokeLater: o outer adiciona o inner ao final da fila durante o drain, entao
+    // o inner roda depois de tudo que ja estava na fila — incluindo o highlightChoice
+    // do QH. Funciona independente da ordem de registro dos plugins.
+    //
+    // Demais interfaces (NPC/PLAYER/SPRITE): o QH nao mexe nelas, um invokeLater
+    // simples basta.
+    static void scheduleDialogTranslation(ClientThread clientThread, int interfaceId, Runnable task)
+    {
+        if (interfaceId == InterfaceID.DIALOG_OPTION)
+        {
+            clientThread.invokeLater(() -> clientThread.invokeLater(task));
+        }
+        else
+        {
+            clientThread.invokeLater(task);
+        }
+    }
+
+    // Retorna o prefixo "[N] " que o QH adiciona a uma opcao destacada, ou "" se nao houver.
+    static String extractNumberingPrefix(String clean)
+    {
+        Matcher m = NUMBERING_PREFIX.matcher(clean);
+        return m.find() ? m.group() : "";
+    }
+
+    // Retorna o texto sem o prefixo "[N] " do QH no inicio, se presente.
+    static String stripNumberingPrefix(String clean)
+    {
+        return NUMBERING_PREFIX.matcher(clean).replaceFirst("");
+    }
+}


### PR DESCRIPTION
Opa @walterrezende12-tech tudo tranquilo?
Vi essa issue https://github.com/walterrezende12-tech/Traducao-OSRS-BR/issues/1 e rodei umas interações aqui com o Claude pra tentar entender o conflito.

Pelo que eu entendi é um problema de concorrência mesmo, os 2 plugins usam o `clientThread.invokeLater` pra jogar o processamento pra uma fila e quem rodar primeiro substitui o texto. Não sei dizer se a ordem de instalação faz diferença nisso, mas o Runelite deve gerenciar essa ordenação internamente.

Em tese, uma forma rápida de resolver é encadear as chamadas que colocam o processamento do texto na fila, pq quando for rodar o plugin de tradução, ele vai jogar de volta pro final da fila, dando tempo do Quest Helper processar primeiro (é meio gambiarra, mas não consegui encontrar uma forma mais limpa de fazer).

Eu implementei essa correção + um regex de detecção do `[1]` que o Quest Helper adiciona nos diálogos, só não consegui testar pq não sei como fazer isso com o Runelite 😭, então não sei dizer se está funcionando. Fica mais como uma sugestão de caminho pra tentar resolver esse problema.

Se ver que tá funcionando ou que precisa de algum ajuste é só falar que eu posso atualizar o Pull Request (PR)
Qualquer dúvida também é só comentar 🚀 
